### PR TITLE
Generate TypeScript definitions from JSDoc comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ dist
 .DS_Store
 package-lock.json
 
+# Generated TypeScript definitions
+types/

--- a/docs/api.md
+++ b/docs/api.md
@@ -134,7 +134,7 @@ of point return vs time to reach further blocks, which often involves digging ot
     * [.entityNamesMatch(targetName, entity, [options])](#RGBot+entityNamesMatch) ⇒ <code>boolean</code>
     * [.handlePath([pathFunc], [options])](#RGBot+handlePath) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.findEntity([options])](#RGBot+findEntity) ⇒ <code>Entity</code> \| <code>null</code>
-    * [.findEntities([options])](#RGBot+findEntities) ⇒ [<code>Array.&lt;FindResult&gt;</code>](#FindResult)
+    * [.findEntities([options])](#RGBot+findEntities) ⇒ <code>Array.&lt;FindResult.&lt;Entity&gt;&gt;</code>
     * [.approachEntity(entity, [options])](#RGBot+approachEntity) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.followEntity(entity, [options])](#RGBot+followEntity) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.avoidEntity(entity, [options])](#RGBot+avoidEntity) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -143,7 +143,7 @@ of point return vs time to reach further blocks, which often involves digging ot
     * [.moveAwayFrom(position, distance)](#RGBot+moveAwayFrom) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.wander([minDistance], [maxDistance])](#RGBot+wander) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.findBlock(blockType, [options])](#RGBot+findBlock) ⇒ <code>Block</code> \| <code>null</code>
-    * [.findBlocks([options])](#RGBot+findBlocks) ⇒ [<code>Array.&lt;FindResult&gt;</code>](#FindResult)
+    * [.findBlocks([options])](#RGBot+findBlocks) ⇒ <code>Array.&lt;FindResult.&lt;Block&gt;&gt;</code>
     * [.approachBlock(block, [options])](#RGBot+approachBlock) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.placeBlock(blockName, targetBlock, [options])](#RGBot+placeBlock) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.equipBestHarvestTool(block)](#RGBot+equipBestHarvestTool) ⇒ <code>Promise.&lt;(Item\|null)&gt;</code>
@@ -153,7 +153,7 @@ of point return vs time to reach further blocks, which often involves digging ot
     * [.findAndDigBlock(blockType, [options])](#RGBot+findAndDigBlock) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.approachAndDigBlock(block, [options])](#RGBot+approachAndDigBlock) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.findItemOnGround(itemName, [options])](#RGBot+findItemOnGround) ⇒ <code>Item</code> \| <code>null</code>
-    * [.findItemsOnGround([options])](#RGBot+findItemsOnGround) ⇒ [<code>Array.&lt;FindResult&gt;</code>](#FindResult)
+    * [.findItemsOnGround([options])](#RGBot+findItemsOnGround) ⇒ <code>Array.&lt;FindResult.&lt;Item&gt;&gt;</code>
     * [.collectItemOnGround(item)](#RGBot+collectItemOnGround) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.findAndCollectItemsOnGround([options])](#RGBot+findAndCollectItemsOnGround) ⇒ <code>Promise.&lt;Array.&lt;Item&gt;&gt;</code>
     * [.inventoryContainsItem(itemName, [options])](#RGBot+inventoryContainsItem) ⇒ <code>boolean</code>
@@ -557,10 +557,10 @@ rgBot.findEntity({targetName: "chicken"})
 
 <br><a name="RGBot+findEntities"></a>
 
-### rgBot.findEntities([options]) ⇒ [<code>Array.&lt;FindResult&gt;</code>](#FindResult)
+### rgBot.findEntities([options]) ⇒ <code>Array.&lt;FindResult.&lt;Entity&gt;&gt;</code>
 > Find the nearest entity matching the search criteria.
 
-**Returns**: [<code>Array.&lt;FindResult&gt;</code>](#FindResult) - To get only the 'best' entity result, call findEntities(...).shift().  Note that the result may be null if no entities were found  
+**Returns**: <code>Array.&lt;FindResult.&lt;Entity&gt;&gt;</code> - To get only the 'best' entity result, call findEntities(...).shift().  Note that the result may be null if no entities were found  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -703,10 +703,10 @@ while (target.isValid) {
 
 <br><a name="RGBot+findBlocks"></a>
 
-### rgBot.findBlocks([options]) ⇒ [<code>Array.&lt;FindResult&gt;</code>](#FindResult)
+### rgBot.findBlocks([options]) ⇒ <code>Array.&lt;FindResult.&lt;Block&gt;&gt;</code>
 > Returns the best block that is diggable within a maximum distance from the Bot.
 
-**Returns**: [<code>Array.&lt;FindResult&gt;</code>](#FindResult) - - the best blocks found
+**Returns**: <code>Array.&lt;FindResult.&lt;Block&gt;&gt;</code> - - the best blocks found
 
 To get only the 'best' block result, call findBlocks(...).shift().  Note that the result may be null if no blocks were found  
 
@@ -851,10 +851,10 @@ To get only the 'best' block result, call findBlocks(...).shift().  Note that th
 
 <br><a name="RGBot+findItemsOnGround"></a>
 
-### rgBot.findItemsOnGround([options]) ⇒ [<code>Array.&lt;FindResult&gt;</code>](#FindResult)
+### rgBot.findItemsOnGround([options]) ⇒ <code>Array.&lt;FindResult.&lt;Item&gt;&gt;</code>
 > Returns a list of all Items that are on the ground within a maximum distance from the Bot (can be empty).
 
-**Returns**: [<code>Array.&lt;FindResult&gt;</code>](#FindResult) - - the best items found
+**Returns**: <code>Array.&lt;FindResult.&lt;Item&gt;&gt;</code> - - the best items found
 
 To get only the 'best' item to collect, call findItems(...).shift().  Note that the result may be null if no items were found  
 
@@ -1145,7 +1145,7 @@ To get only the 'best' item to collect, call findItems(...).shift().  Note that 
 
 * [FindResult](#FindResult)
     * [new FindResult(result, value)](#new_FindResult_new)
-    * [.result](#FindResult+result) : <code>Entity</code> \| <code>Item</code> \| <code>Block</code>
+    * [.result](#FindResult+result) : <code>T</code>
     * [.value](#FindResult+value) : <code>number</code>
 
 
@@ -1155,13 +1155,13 @@ To get only the 'best' item to collect, call findItems(...).shift().  Note that 
 
 | Param | Type | Description |
 | --- | --- | --- |
-| result | <code>Entity</code>, <code>Item</code>, <code>Block</code> | The result object |
+| result | <code>T</code> | The result object |
 | value | <code>number</code> | The value computed for this result during evaluation |
 
 
 <br><a name="FindResult+result"></a>
 
-### findResult.result : <code>Entity</code> \| <code>Item</code> \| <code>Block</code>
+### findResult.result : <code>T</code>
 
 <br><a name="FindResult+value"></a>
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,24 +58,18 @@ of point return vs time to reach further blocks, which often involves digging ot
 ## Typedefs
 
 <dl>
-<dt><a href="#FindEntitiesEntityValueFunction">FindEntitiesEntityValueFunction</a> : <code>function</code></dt>
-<dd><p>Signature: <code>(entityName: string) =&gt; number</code></p>
-</dd>
-<dt><a href="#FindEntitiesSortValueFunction">FindEntitiesSortValueFunction</a> : <code>function</code></dt>
-<dd><p>Signature: <code>(distance: number, pointValue: number, health: number, defense: number, toughness: number) =&gt; number</code></p>
-</dd>
-<dt><a href="#FindBlocksBlockValueFunction">FindBlocksBlockValueFunction</a> : <code>function</code></dt>
-<dd><p>Signature: <code>(blockName: string) =&gt; number</code></p>
-</dd>
-<dt><a href="#FindBlocksSortValueFunction">FindBlocksSortValueFunction</a> : <code>function</code></dt>
-<dd><p>Signature: <code>(distance: number, pointValue: number, digTime: number) =&gt; number</code></p>
-</dd>
-<dt><a href="#FindItemsOnGroundItemValueFunction">FindItemsOnGroundItemValueFunction</a> : <code>function</code></dt>
-<dd><p>Signature: <code>(blockName: string) =&gt; number</code></p>
-</dd>
-<dt><a href="#FindItemsOnGroundSortValueFunction">FindItemsOnGroundSortValueFunction</a> : <code>function</code></dt>
-<dd><p>Signature: <code>(distance: number, pointValue: number) =&gt; number</code></p>
-</dd>
+<dt><a href="#FindEntitiesEntityValueFunction">FindEntitiesEntityValueFunction</a> ⇒ <code>number</code></dt>
+<dd></dd>
+<dt><a href="#FindEntitiesSortValueFunction">FindEntitiesSortValueFunction</a> ⇒ <code>number</code></dt>
+<dd></dd>
+<dt><a href="#FindBlocksBlockValueFunction">FindBlocksBlockValueFunction</a> ⇒ <code>number</code></dt>
+<dd></dd>
+<dt><a href="#FindBlocksSortValueFunction">FindBlocksSortValueFunction</a> ⇒ <code>number</code></dt>
+<dd></dd>
+<dt><a href="#FindItemsOnGroundItemValueFunction">FindItemsOnGroundItemValueFunction</a> ⇒ <code>number</code></dt>
+<dd></dd>
+<dt><a href="#FindItemsOnGroundSortValueFunction">FindItemsOnGroundSortValueFunction</a> ⇒ <code>number</code></dt>
+<dd></dd>
 </dl>
 
 
@@ -576,8 +570,8 @@ rgBot.findEntity({targetName: "chicken"})
 | [options.partialMatch] | <code>boolean</code> | <code>false</code> | Consider entities whose username or name partially match one of the targetNames |
 | [options.maxDistance] | <code>number</code> |  | Max range to consider |
 | [options.maxCount] | <code>number</code> | <code>1</code> | Max count of matching entities to consider |
-| [options.entityValueFunction] | [<code>FindEntitiesEntityValueFunction</code>](#FindEntitiesEntityValueFunction) |  | Signature: `(entityName: string) => number`. Function to call to get the value of an entity based on its name (entityName). A good example function is { return scoreValueOf[entityUsername || entityName] }, where scoreValueOf is the point value or intrinsic value of the entity in the game mode being played.  If you don't want an entity considered, return a value < 0 for its value. Default value is 0 if no function is provided. |
-| [options.sortValueFunction] | [<code>FindEntitiesSortValueFunction</code>](#FindEntitiesSortValueFunction) |  | Signature: `(distance: number, pointValue: number, health: number, defense: number, toughness: number) => number`. Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION |
+| [options.entityValueFunction] | [<code>FindEntitiesEntityValueFunction</code>](#FindEntitiesEntityValueFunction) |  | Function to call to get the value of an entity based on its name (entityName). A good example function is { return scoreValueOf[entityUsername || entityName] }, where scoreValueOf is the point value or intrinsic value of the entity in the game mode being played.  If you don't want an entity considered, return a value < 0 for its value. Default value is 0 if no function is provided. |
+| [options.sortValueFunction] | [<code>FindEntitiesSortValueFunction</code>](#FindEntitiesSortValueFunction) |  | Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION |
 
 
 <br><a name="RGBot+approachEntity"></a>
@@ -724,8 +718,8 @@ To get only the 'best' block result, call findBlocks(...).shift().  Note that th
 | [options.onlyFindTopBlocks] | <code>boolean</code> | <code>false</code> | Only find blocks that don't have a block above them. |
 | [options.maxDistance] | <code>number</code> | <code>30</code> | Max range to consider.  Be careful as large values have performance implications.  30 means up to 60x60x60 (216000) blocks could be evaluated.  50 means up to 100x100x100 (1000000) blocks could be evaluated |
 | [options.maxCount] | <code>number</code> | <code>1</code> | Max count of matching blocks |
-| [options.blockValueFunction] | [<code>FindBlocksBlockValueFunction</code>](#FindBlocksBlockValueFunction) |  | Signature: `(blockName: string) => number`. Function to call to get the value of a block based on its name (blockName). A good example function is { return scoreValueOf[blockName] }, where scoreValueOf is the point value or intrinsic value of the block in the game mode being played.  If you don't want a block considered, return a value < 0 for its value. Default value is 0 if no function is provided. |
-| [options.sortValueFunction] | [<code>FindBlocksSortValueFunction</code>](#FindBlocksSortValueFunction) |  | Signature: `(distance: number, pointValue: number, digTime: number) => number`. Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION |
+| [options.blockValueFunction] | [<code>FindBlocksBlockValueFunction</code>](#FindBlocksBlockValueFunction) |  | Function to call to get the value of a block based on its name (blockName). A good example function is { return scoreValueOf[blockName] }, where scoreValueOf is the point value or intrinsic value of the block in the game mode being played.  If you don't want a block considered, return a value < 0 for its value. Default value is 0 if no function is provided. |
+| [options.sortValueFunction] | [<code>FindBlocksSortValueFunction</code>](#FindBlocksSortValueFunction) |  | Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION |
 
 
 <br><a name="RGBot+approachBlock"></a>
@@ -871,8 +865,8 @@ To get only the 'best' item to collect, call findItems(...).shift().  Note that 
 | [options.partialMatch] | <code>boolean</code> | <code>false</code> | If itemNames is defined, find Items whose name contains any of the itemNames. (Ex. '_boots' may find any of 'iron_boots', 'golden_boots', etc.) |
 | [options.maxDistance] | <code>number</code> |  | find any Items matching the search criteria up to and including this distance from the Bot |
 | [options.maxCount] | <code>number</code> | <code>1</code> | limit the number of items to find |
-| [options.itemValueFunction] | [<code>FindItemsOnGroundItemValueFunction</code>](#FindItemsOnGroundItemValueFunction) |  | Signature: `(blockName: string) => number`. Function to call to get the value of an item based on its name (itemName). A good example function is { return scoreValueOf[itemName] }, where scoreValueOf is the point value or intrinsic value of the item in the game mode being played.  If you don't want an item considered, return a value < 0 for its value.  Default value is 0. |
-| [options.sortValueFunction] | [<code>FindItemsOnGroundSortValueFunction</code>](#FindItemsOnGroundSortValueFunction) |  | Signature: `(distance: number, pointValue: number) => number`. Function to call to help sort the evaluation of results. Should return the best item with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION |
+| [options.itemValueFunction] | [<code>FindItemsOnGroundItemValueFunction</code>](#FindItemsOnGroundItemValueFunction) |  | Function to call to get the value of an item based on its name (itemName). A good example function is { return scoreValueOf[itemName] }, where scoreValueOf is the point value or intrinsic value of the item in the game mode being played.  If you don't want an item considered, return a value < 0 for its value.  Default value is 0. |
+| [options.sortValueFunction] | [<code>FindItemsOnGroundSortValueFunction</code>](#FindItemsOnGroundSortValueFunction) |  | Function to call to help sort the evaluation of results. Should return the best item with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION |
 
 
 <br><a name="RGBot+collectItemOnGround"></a>
@@ -1221,36 +1215,61 @@ To get only the 'best' item to collect, call findItems(...).shift().  Note that 
 
 <br><a name="FindEntitiesEntityValueFunction"></a>
 
-## FindEntitiesEntityValueFunction : <code>function</code>
-> Signature: `(entityName: string) => number`
+## FindEntitiesEntityValueFunction ⇒ <code>number</code>
+
+| Param | Type |
+| --- | --- |
+| entityName | <code>string</code> | 
 
 
 <br><a name="FindEntitiesSortValueFunction"></a>
 
-## FindEntitiesSortValueFunction : <code>function</code>
-> Signature: `(distance: number, pointValue: number, health: number, defense: number, toughness: number) => number`
+## FindEntitiesSortValueFunction ⇒ <code>number</code>
+
+| Param | Type |
+| --- | --- |
+| distance | <code>number</code> | 
+| pointValue | <code>number</code> | 
+| health | <code>number</code> | 
+| defense | <code>number</code> | 
+| toughness | <code>number</code> | 
 
 
 <br><a name="FindBlocksBlockValueFunction"></a>
 
-## FindBlocksBlockValueFunction : <code>function</code>
-> Signature: `(blockName: string) => number`
+## FindBlocksBlockValueFunction ⇒ <code>number</code>
+
+| Param | Type |
+| --- | --- |
+| blockName | <code>string</code> | 
 
 
 <br><a name="FindBlocksSortValueFunction"></a>
 
-## FindBlocksSortValueFunction : <code>function</code>
-> Signature: `(distance: number, pointValue: number, digTime: number) => number`
+## FindBlocksSortValueFunction ⇒ <code>number</code>
+
+| Param | Type |
+| --- | --- |
+| distance | <code>number</code> | 
+| pointValue | <code>number</code> | 
+| digTime | <code>number</code> | 
 
 
 <br><a name="FindItemsOnGroundItemValueFunction"></a>
 
-## FindItemsOnGroundItemValueFunction : <code>function</code>
-> Signature: `(blockName: string) => number`
+## FindItemsOnGroundItemValueFunction ⇒ <code>number</code>
+
+| Param | Type |
+| --- | --- |
+| blockName | <code>string</code> | 
 
 
 <br><a name="FindItemsOnGroundSortValueFunction"></a>
 
-## FindItemsOnGroundSortValueFunction : <code>function</code>
-> Signature: `(distance: number, pointValue: number) => number`
+## FindItemsOnGroundSortValueFunction ⇒ <code>number</code>
+
+| Param | Type |
+| --- | --- |
+| distance | <code>number</code> | 
+| pointValue | <code>number</code> | 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,18 +41,41 @@ The digTime will be Infinity if the block is not diggable with any tool the bot 
 ## Functions
 
 <dl>
-<dt><a href="#DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION">DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION(distance, pointValue, digTime)</a> ⇒ <code>number</code></dt>
+<dt><a href="#DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION">DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION(distance, [pointValue], [digTime])</a> ⇒ <code>number</code></dt>
 <dd><p>MC character running speed is 5 blocks per second, up to 9 with soul speed 3.
 Distance to travel doesn&#39;t always mean flat ground running.
 Sometimes distance implies non-linear paths or block digging, but this default gives a reasonable estimate</p>
 <p>After some experimentation/white-boarding, we found that pointValue-distance-digTime gives a reasonable balance
 of point return vs time to reach further blocks, which often involves digging other blocks first.</p>
 </dd>
-<dt><a href="#DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION">DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION(distance, pointValue, health, defense, toughness)</a> ⇒ <code>number</code></dt>
+<dt><a href="#DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION">DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION(distance, pointValue, [health], [defense], [toughness])</a> ⇒ <code>number</code></dt>
 <dd><p>For Reference In Minecraft: (damageTaken = damage * (1 - min(20, max(defense / 5, defense - damage / (toughness / 4 + 2)))) / 25)</p>
 </dd>
-<dt><a href="#DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION">DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION(distance, pointValue)</a> ⇒ <code>number</code></dt>
+<dt><a href="#DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION">DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION(distance, [pointValue])</a> ⇒ <code>number</code></dt>
 <dd></dd>
+</dl>
+
+## Typedefs
+
+<dl>
+<dt><a href="#FindEntitiesEntityValueFunction">FindEntitiesEntityValueFunction</a> : <code>function</code></dt>
+<dd><p>Signature: <code>(entityName: string) =&gt; number</code></p>
+</dd>
+<dt><a href="#FindEntitiesSortValueFunction">FindEntitiesSortValueFunction</a> : <code>function</code></dt>
+<dd><p>Signature: <code>(distance: number, pointValue: number, health: number, defense: number, toughness: number) =&gt; number</code></p>
+</dd>
+<dt><a href="#FindBlocksBlockValueFunction">FindBlocksBlockValueFunction</a> : <code>function</code></dt>
+<dd><p>Signature: <code>(blockName: string) =&gt; number</code></p>
+</dd>
+<dt><a href="#FindBlocksSortValueFunction">FindBlocksSortValueFunction</a> : <code>function</code></dt>
+<dd><p>Signature: <code>(distance: number, pointValue: number, digTime: number) =&gt; number</code></p>
+</dd>
+<dt><a href="#FindItemsOnGroundItemValueFunction">FindItemsOnGroundItemValueFunction</a> : <code>function</code></dt>
+<dd><p>Signature: <code>(blockName: string) =&gt; number</code></p>
+</dd>
+<dt><a href="#FindItemsOnGroundSortValueFunction">FindItemsOnGroundSortValueFunction</a> : <code>function</code></dt>
+<dd><p>Signature: <code>(distance: number, pointValue: number) =&gt; number</code></p>
+</dd>
 </dl>
 
 
@@ -124,7 +147,7 @@ of point return vs time to reach further blocks, which often involves digging ot
     * [.attackEntity(entity, [options])](#RGBot+attackEntity) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.waitForWeaponCoolDown()](#RGBot+waitForWeaponCoolDown) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.moveAwayFrom(position, distance)](#RGBot+moveAwayFrom) ⇒ <code>Promise.&lt;boolean&gt;</code>
-    * [.wander(minDistance, maxDistance)](#RGBot+wander) ⇒ <code>Promise.&lt;boolean&gt;</code>
+    * [.wander([minDistance], [maxDistance])](#RGBot+wander) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.findBlock(blockType, [options])](#RGBot+findBlock) ⇒ <code>Block</code> \| <code>null</code>
     * [.findBlocks([options])](#RGBot+findBlocks) ⇒ [<code>Array.&lt;FindResult&gt;</code>](#FindResult)
     * [.approachBlock(block, [options])](#RGBot+approachBlock) ⇒ <code>Promise.&lt;boolean&gt;</code>
@@ -140,7 +163,7 @@ of point return vs time to reach further blocks, which often involves digging ot
     * [.collectItemOnGround(item)](#RGBot+collectItemOnGround) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.findAndCollectItemsOnGround([options])](#RGBot+findAndCollectItemsOnGround) ⇒ <code>Promise.&lt;Array.&lt;Item&gt;&gt;</code>
     * [.inventoryContainsItem(itemName, [options])](#RGBot+inventoryContainsItem) ⇒ <code>boolean</code>
-    * [.getInventoryItemQuantity(itemName, [options])](#RGBot+getInventoryItemQuantity) ⇒ <code>int</code>
+    * [.getInventoryItemQuantity(itemName, [options])](#RGBot+getInventoryItemQuantity) ⇒ <code>number</code>
     * [.dropInventoryItem(itemName, [options])](#RGBot+dropInventoryItem) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.isInventorySlotsFull()](#RGBot+isInventorySlotsFull) ⇒ <code>boolean</code>
     * [.getAllInventoryItems()](#RGBot+getAllInventoryItems) ⇒ <code>Array.&lt;Item&gt;</code>
@@ -553,8 +576,8 @@ rgBot.findEntity({targetName: "chicken"})
 | [options.partialMatch] | <code>boolean</code> | <code>false</code> | Consider entities whose username or name partially match one of the targetNames |
 | [options.maxDistance] | <code>number</code> |  | Max range to consider |
 | [options.maxCount] | <code>number</code> | <code>1</code> | Max count of matching entities to consider |
-| [options.entityValueFunction] | <code>function</code> |  | Function to call to get the value of an entity based on its name (entityName). A good example function is { return scoreValueOf[entityUsername || entityName] }, where scoreValueOf is the point value or intrinsic value of the entity in the game mode being played.  If you don't want an entity considered, return a value < 0 for its value. Default value is 0 if no function is provided. |
-| [options.sortValueFunction] | <code>function</code> |  | function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION |
+| [options.entityValueFunction] | [<code>FindEntitiesEntityValueFunction</code>](#FindEntitiesEntityValueFunction) |  | Signature: `(entityName: string) => number`. Function to call to get the value of an entity based on its name (entityName). A good example function is { return scoreValueOf[entityUsername || entityName] }, where scoreValueOf is the point value or intrinsic value of the entity in the game mode being played.  If you don't want an entity considered, return a value < 0 for its value. Default value is 0 if no function is provided. |
+| [options.sortValueFunction] | [<code>FindEntitiesSortValueFunction</code>](#FindEntitiesSortValueFunction) |  | Signature: `(distance: number, pointValue: number, health: number, defense: number, toughness: number) => number`. Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION |
 
 
 <br><a name="RGBot+approachEntity"></a>
@@ -656,7 +679,7 @@ while (target.isValid) {
 
 <br><a name="RGBot+wander"></a>
 
-### rgBot.wander(minDistance, maxDistance) ⇒ <code>Promise.&lt;boolean&gt;</code>
+### rgBot.wander([minDistance], [maxDistance]) ⇒ <code>Promise.&lt;boolean&gt;</code>
 > Choose a random point within a minimum and maximum radius around the Bot and approach it.
 > Points are calculated on the X and Z axes.
 
@@ -664,8 +687,8 @@ while (target.isValid) {
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| minDistance | <code>number</code> | <code>10</code> | The minimum distance the point may be from the Bot |
-| maxDistance | <code>number</code> | <code>10</code> | The maximum distance the point may be from the Bot |
+| [minDistance] | <code>number</code> | <code>10</code> | The minimum distance the point may be from the Bot |
+| [maxDistance] | <code>number</code> | <code>10</code> | The maximum distance the point may be from the Bot |
 
 
 <br><a name="RGBot+findBlock"></a>
@@ -701,8 +724,8 @@ To get only the 'best' block result, call findBlocks(...).shift().  Note that th
 | [options.onlyFindTopBlocks] | <code>boolean</code> | <code>false</code> | Only find blocks that don't have a block above them. |
 | [options.maxDistance] | <code>number</code> | <code>30</code> | Max range to consider.  Be careful as large values have performance implications.  30 means up to 60x60x60 (216000) blocks could be evaluated.  50 means up to 100x100x100 (1000000) blocks could be evaluated |
 | [options.maxCount] | <code>number</code> | <code>1</code> | Max count of matching blocks |
-| [options.blockValueFunction] | <code>function</code> |  | Function to call to get the value of a block based on its name (blockName). A good example function is { return scoreValueOf[blockName] }, where scoreValueOf is the point value or intrinsic value of the block in the game mode being played.  If you don't want a block considered, return a value < 0 for its value. Default value is 0 if no function is provided. |
-| [options.sortValueFunction] | <code>function</code> |  | Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION |
+| [options.blockValueFunction] | [<code>FindBlocksBlockValueFunction</code>](#FindBlocksBlockValueFunction) |  | Signature: `(blockName: string) => number`. Function to call to get the value of a block based on its name (blockName). A good example function is { return scoreValueOf[blockName] }, where scoreValueOf is the point value or intrinsic value of the block in the game mode being played.  If you don't want a block considered, return a value < 0 for its value. Default value is 0 if no function is provided. |
+| [options.sortValueFunction] | [<code>FindBlocksSortValueFunction</code>](#FindBlocksSortValueFunction) |  | Signature: `(distance: number, pointValue: number, digTime: number) => number`. Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION |
 
 
 <br><a name="RGBot+approachBlock"></a>
@@ -848,8 +871,8 @@ To get only the 'best' item to collect, call findItems(...).shift().  Note that 
 | [options.partialMatch] | <code>boolean</code> | <code>false</code> | If itemNames is defined, find Items whose name contains any of the itemNames. (Ex. '_boots' may find any of 'iron_boots', 'golden_boots', etc.) |
 | [options.maxDistance] | <code>number</code> |  | find any Items matching the search criteria up to and including this distance from the Bot |
 | [options.maxCount] | <code>number</code> | <code>1</code> | limit the number of items to find |
-| [options.itemValueFunction] | <code>function</code> |  | function to call to get the value of an item based on its name (itemName). A good example function is { return scoreValueOf[itemName] }, where scoreValueOf is the point value or intrinsic value of the item in the game mode being played.  If you don't want an item considered, return a value < 0 for its value.  Default value is 0. |
-| [options.sortValueFunction] | <code>function</code> |  | function to call to help sort the evaluation of results. Should return the best item with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION |
+| [options.itemValueFunction] | [<code>FindItemsOnGroundItemValueFunction</code>](#FindItemsOnGroundItemValueFunction) |  | Signature: `(blockName: string) => number`. Function to call to get the value of an item based on its name (itemName). A good example function is { return scoreValueOf[itemName] }, where scoreValueOf is the point value or intrinsic value of the item in the game mode being played.  If you don't want an item considered, return a value < 0 for its value.  Default value is 0. |
+| [options.sortValueFunction] | [<code>FindItemsOnGroundSortValueFunction</code>](#FindItemsOnGroundSortValueFunction) |  | Signature: `(distance: number, pointValue: number) => number`. Function to call to help sort the evaluation of results. Should return the best item with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION |
 
 
 <br><a name="RGBot+collectItemOnGround"></a>
@@ -895,7 +918,7 @@ To get only the 'best' item to collect, call findItems(...).shift().  Note that 
 
 <br><a name="RGBot+getInventoryItemQuantity"></a>
 
-### rgBot.getInventoryItemQuantity(itemName, [options]) ⇒ <code>int</code>
+### rgBot.getInventoryItemQuantity(itemName, [options]) ⇒ <code>number</code>
 > Return how many of a specific item the Bot currently holds in its inventory.
 
 
@@ -1097,24 +1120,24 @@ To get only the 'best' item to collect, call findItems(...).shift().  Note that 
 
 
 * [BestHarvestTool](#BestHarvestTool)
-    * [new BestHarvestTool(tool, digTime)](#new_BestHarvestTool_new)
-    * [.tool](#BestHarvestTool+tool) : <code>Item</code>
+    * [new BestHarvestTool(tool, [digTime])](#new_BestHarvestTool_new)
+    * [.tool](#BestHarvestTool+tool) : <code>Item</code> \| <code>null</code>
     * [.digTime](#BestHarvestTool+digTime) : <code>number</code>
 
 
 <br><a name="new_BestHarvestTool_new"></a>
 
-### new BestHarvestTool(tool, digTime)
+### new BestHarvestTool(tool, [digTime])
 
-| Param | Type | Description |
-| --- | --- | --- |
-| tool | <code>Item</code>, <code>null</code> | The Item best suited to dig the block.  Can be null if no tool is needed or if item is not diggable. |
-| digTime | <code>number</code> | Time in milliseconds to dig the block, Infinity if not diggable |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| tool | <code>Item</code>, <code>null</code> |  | The Item best suited to dig the block.  Can be null if no tool is needed or if item is not diggable. |
+| [digTime] | <code>number</code> | <code>Infinity</code> | Time in milliseconds to dig the block, Infinity if not diggable |
 
 
 <br><a name="BestHarvestTool+tool"></a>
 
-### bestHarvestTool.tool : <code>Item</code>
+### bestHarvestTool.tool : <code>Item</code> \| <code>null</code>
 
 <br><a name="BestHarvestTool+digTime"></a>
 
@@ -1152,7 +1175,7 @@ To get only the 'best' item to collect, call findItems(...).shift().  Note that 
 
 <br><a name="DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION"></a>
 
-## DEFAULT\_FIND\_BLOCKS\_SORT\_VALUE\_FUNCTION(distance, pointValue, digTime) ⇒ <code>number</code>
+## DEFAULT\_FIND\_BLOCKS\_SORT\_VALUE\_FUNCTION(distance, [pointValue], [digTime]) ⇒ <code>number</code>
 > MC character running speed is 5 blocks per second, up to 9 with soul speed 3.
 > Distance to travel doesn't always mean flat ground running.
 > Sometimes distance implies non-linear paths or block digging, but this default gives a reasonable estimate
@@ -1165,33 +1188,69 @@ To get only the 'best' item to collect, call findItems(...).shift().  Note that 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | distance | <code>number</code> |  | Blocks away |
-| pointValue | <code>number</code> | <code>0</code> | Score or Intrinsic value of the block being considered |
-| digTime | <code>number</code> | <code>0</code> | milliseconds |
+| [pointValue] | <code>number</code> | <code>0</code> | Score or Intrinsic value of the block being considered |
+| [digTime] | <code>number</code> | <code>0</code> | milliseconds |
 
 
 <br><a name="DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION"></a>
 
-## DEFAULT\_FIND\_ENTITIES\_SORT\_VALUE\_FUNCTION(distance, pointValue, health, defense, toughness) ⇒ <code>number</code>
+## DEFAULT\_FIND\_ENTITIES\_SORT\_VALUE\_FUNCTION(distance, pointValue, [health], [defense], [toughness]) ⇒ <code>number</code>
 > For Reference In Minecraft: (damageTaken = damage * (1 - min(20, max(defense / 5, defense - damage / (toughness / 4 + 2)))) / 25)
 
 **Returns**: <code>number</code> - The sorting value computed.  The 'best' target to attack should have lower sorting values  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| distance |  |  | Blocks away |
+| distance | <code>number</code> |  | Blocks away |
 | pointValue | <code>number</code> |  | Score or Intrinsic value of the entity being considered |
-| health |  | <code>10</code> | Health of the target (normally 0->20, passive NPCs have 10 health) |
-| defense |  | <code>0</code> | Defense value of the target |
-| toughness |  | <code>0</code> | Toughness value of the target |
+| [health] | <code>number</code> | <code>10</code> | Health of the target (normally 0->20, passive NPCs have 10 health) |
+| [defense] | <code>number</code> | <code>0</code> | Defense value of the target |
+| [toughness] | <code>number</code> | <code>0</code> | Toughness value of the target |
 
 
 <br><a name="DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION"></a>
 
-## DEFAULT\_FIND\_ITEMS\_ON\_GROUND\_SORT\_VALUE\_FUNCTION(distance, pointValue) ⇒ <code>number</code>
+## DEFAULT\_FIND\_ITEMS\_ON\_GROUND\_SORT\_VALUE\_FUNCTION(distance, [pointValue]) ⇒ <code>number</code>
 **Returns**: <code>number</code> - The sorting value computed.  The 'best' item to collect should have lower sorting values  
 
-| Param | Default | Description |
-| --- | --- | --- |
-| distance |  | Blocks away |
-| pointValue | <code>0</code> | Score or Intrinsic value of the block being considered |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| distance | <code>number</code> |  | Blocks away |
+| [pointValue] | <code>number</code> | <code>0</code> | Score or Intrinsic value of the block being considered |
+
+
+<br><a name="FindEntitiesEntityValueFunction"></a>
+
+## FindEntitiesEntityValueFunction : <code>function</code>
+> Signature: `(entityName: string) => number`
+
+
+<br><a name="FindEntitiesSortValueFunction"></a>
+
+## FindEntitiesSortValueFunction : <code>function</code>
+> Signature: `(distance: number, pointValue: number, health: number, defense: number, toughness: number) => number`
+
+
+<br><a name="FindBlocksBlockValueFunction"></a>
+
+## FindBlocksBlockValueFunction : <code>function</code>
+> Signature: `(blockName: string) => number`
+
+
+<br><a name="FindBlocksSortValueFunction"></a>
+
+## FindBlocksSortValueFunction : <code>function</code>
+> Signature: `(distance: number, pointValue: number, digTime: number) => number`
+
+
+<br><a name="FindItemsOnGroundItemValueFunction"></a>
+
+## FindItemsOnGroundItemValueFunction : <code>function</code>
+> Signature: `(blockName: string) => number`
+
+
+<br><a name="FindItemsOnGroundSortValueFunction"></a>
+
+## FindItemsOnGroundSortValueFunction : <code>function</code>
+> Signature: `(distance: number, pointValue: number) => number`
 

--- a/docs/jsdoc.json
+++ b/docs/jsdoc.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["docs/remove-typescript-syntax"]
+}

--- a/docs/remove-typescript-syntax.js
+++ b/docs/remove-typescript-syntax.js
@@ -1,0 +1,17 @@
+exports.handlers = {
+  /**
+   * In order to generate TypeScript definitions from JSDoc comments we need to use TypeScript-specific JSDoc syntax:
+   * https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#import-types
+   * 
+   * In the JSDoc comments we prefix all blocks of TypeScript-specific syntax with "TypeScript JSDoc:",
+   * which we remove here. This way we can run jsdoc2md without errors, but still use TypeScript-specific syntax
+   * to improve the generated TypeScript definition files.
+   *
+   * @param {object} e
+   * @param {string} e.filename
+   * @param {string} e.source
+   */
+  beforeParse(e) {
+    e.source = e.source.replace(/TypeScript JSDoc:\s*(\* @typedef.*\s*)*/gm, '\n');
+  },
+};

--- a/docs/remove-typescript-syntax.js
+++ b/docs/remove-typescript-syntax.js
@@ -3,15 +3,13 @@ exports.handlers = {
    * In order to generate TypeScript definitions from JSDoc comments we need to use TypeScript-specific JSDoc syntax:
    * https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#import-types
    * 
-   * In the JSDoc comments we prefix all blocks of TypeScript-specific syntax with "TypeScript JSDoc:",
-   * which we remove here. This way we can run jsdoc2md without errors, but still use TypeScript-specific syntax
-   * to improve the generated TypeScript definition files.
+   * Here we remove the TypeScript-specific syntax so we can run jsdoc2md without errors.
    *
    * @param {object} e
    * @param {string} e.filename
    * @param {string} e.source
    */
   beforeParse(e) {
-    e.source = e.source.replace(/TypeScript JSDoc:\s*(\* @typedef.*\s*)*/gm, '\n');
+    e.source = e.source.replace(/@typedef\s*{\s*import\(.*}.*$/gm, '');
   },
 };

--- a/lib/RGAlgorithms.js
+++ b/lib/RGAlgorithms.js
@@ -7,8 +7,8 @@
  * of point return vs time to reach further blocks, which often involves digging other blocks first.
  *
  * @param {number} distance Blocks away
- * @param {number} pointValue Score or Intrinsic value of the block being considered
- * @param {number} digTime milliseconds
+ * @param {number} [pointValue=0] Score or Intrinsic value of the block being considered
+ * @param {number} [digTime=0] milliseconds
  * @returns {number} The sorting value computed.  The 'best' blocks should have lower sorting values
  */
 const DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION = (distance, pointValue=0, digTime=0) => {return -1 * (pointValue - distance - digTime/1000)}
@@ -17,11 +17,11 @@ const DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION = (distance, pointValue=0, digTime
  *
  * For Reference In Minecraft: (damageTaken = damage * (1 - min(20, max(defense / 5, defense - damage / (toughness / 4 + 2)))) / 25)
  *
- * @param distance Blocks away
+ * @param {number} distance Blocks away
  * @param {number} pointValue Score or Intrinsic value of the entity being considered
- * @param health Health of the target (normally 0->20, passive NPCs have 10 health)
- * @param defense Defense value of the target
- * @param toughness Toughness value of the target
+ * @param {number} [health=10] Health of the target (normally 0->20, passive NPCs have 10 health)
+ * @param {number} [defense=0] Defense value of the target
+ * @param {number} [toughness=0] Toughness value of the target
  * @returns {number} The sorting value computed.  The 'best' target to attack should have lower sorting values
  */
 // Note: 10 is the passive animal HP and half of max HP for entities
@@ -29,8 +29,8 @@ const DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION = (distance, pointValue, health=
 
 /**
  *
- * @param distance Blocks away
- * @param pointValue Score or Intrinsic value of the block being considered
+ * @param {number} distance Blocks away
+ * @param {number} [pointValue=0] Score or Intrinsic value of the block being considered
  * @returns {number} The sorting value computed.  The 'best' item to collect should have lower sorting values
  */
 const DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION = (distance, pointValue=0) => {return -1 * ((pointValue * 2) - (distance * 1.1)) }

--- a/lib/RGBot.js
+++ b/lib/RGBot.js
@@ -41,7 +41,16 @@ const RGAlgorithms = require('./RGAlgorithms')
  *    As an example, the Ender Dragon is the readable name, or display name, of the Entity named ender_dragon. Likewise, Grass Block is the display name of the block named grass_block.
  *    This library provides functions to accept the name but not the display name for conciseness and efficiency
  */
-const RGBot = class {
+class RGBot {
+    /**
+     * TypeScript JSDoc:
+     * @typedef { import('mineflayer').Bot } Bot
+     * @typedef { import('events').EventEmitter } EventEmitter
+     * @typedef { import('prismarine-item').Item } Item
+     * @typedef { import('prismarine-entity').Entity } Entity
+     * @typedef { import('prismarine-block').Block } Block
+     * @typedef { import('prismarine-windows').Window } Window
+     */
 
     /**
      * This value is read by the handlePath function to know if the bot is busy using a container while evaluating if it is stuck or not.
@@ -563,6 +572,20 @@ const RGBot = class {
     }
 
     /**
+     * TypeScript JSDoc:
+     * @typedef {(entityName: string) => number} FindEntitiesEntityValueFunction
+     * @typedef {(distance: number, pointValue: number, health: number, defense: number, toughness: number) => number} FindEntitiesSortValueFunction
+     */
+
+    /**
+     * @typedef {function(string):number} FindEntitiesEntityValueFunction  Signature: `(entityName: string) => number`
+     */
+
+    /**
+     * @typedef {function(number,number,number,number,number):number} FindEntitiesSortValueFunction Signature: `(distance: number, pointValue: number, health: number, defense: number, toughness: number) => number`
+     */
+
+    /**
      * Find the nearest entity matching the search criteria.
      *
      * @param {object} [options={}]
@@ -571,8 +594,8 @@ const RGBot = class {
      * @param {boolean} [options.partialMatch=false] Consider entities whose username or name partially match one of the targetNames
      * @param {number} [options.maxDistance=undefined]  Max range to consider
      * @param {number} [options.maxCount=1]  Max count of matching entities to consider
-     * @param {function(entityName:string):number} [options.entityValueFunction] Function to call to get the value of an entity based on its name (entityName). A good example function is { return scoreValueOf[entityUsername || entityName] }, where scoreValueOf is the point value or intrinsic value of the entity in the game mode being played.  If you don't want an entity considered, return a value < 0 for its value. Default value is 0 if no function is provided.
-     * @param {function(distance:number,pointValue:number,health:number,defense:number,toughness:number):number} [options.sortValueFunction] function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION
+     * @param {FindEntitiesEntityValueFunction} [options.entityValueFunction] Signature: `(entityName: string) => number`. Function to call to get the value of an entity based on its name (entityName). A good example function is { return scoreValueOf[entityUsername || entityName] }, where scoreValueOf is the point value or intrinsic value of the entity in the game mode being played.  If you don't want an entity considered, return a value < 0 for its value. Default value is 0 if no function is provided.
+     * @param {FindEntitiesSortValueFunction} [options.sortValueFunction] Signature: `(distance: number, pointValue: number, health: number, defense: number, toughness: number) => number`. Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION
      *
      * @return {FindResult[]}
      *
@@ -808,8 +831,8 @@ const RGBot = class {
     /**
      * Choose a random point within a minimum and maximum radius around the Bot and approach it.
      * Points are calculated on the X and Z axes.
-     * @param {number} minDistance=10 The minimum distance the point may be from the Bot
-     * @param {number} maxDistance=10 The maximum distance the point may be from the Bot
+     * @param {number} [minDistance=10] The minimum distance the point may be from the Bot
+     * @param {number} [maxDistance=10] The maximum distance the point may be from the Bot
      * @returns {Promise<boolean>} true if the Bot successfully reached its wander goal, else false
      */
     async wander(minDistance = 10, maxDistance = 10) {
@@ -831,7 +854,7 @@ const RGBot = class {
 
     /**
      * Attempt to locate the nearest block of the given type within a specified range from the Bot.
-     * @param blockType {string} The name or name of the block to find
+     * @param {string} blockType The name or name of the block to find
      * @param {object} [options={}] Optional parameters
      * @param {boolean} [options.partialMatch=false] Find blocks whose name contains blockType. (Ex. 'log' may find any of 'spruce_log', 'oak_log', etc.)
      * @param {boolean} [options.onlyFindTopBlocks=false] Will not return any blocks that are beneath another block
@@ -856,6 +879,20 @@ const RGBot = class {
     }
 
     /**
+     * TypeScript JSDoc:
+     * @typedef {(blockName: string) => number} FindBlocksBlockValueFunction
+     * @typedef {(distance: number, pointValue: number, digTime: number) => number} FindBlocksSortValueFunction
+     */
+
+    /**
+     * @typedef {function(string):number} FindBlocksBlockValueFunction  Signature: `(blockName: string) => number`
+     */
+
+    /**
+     * @typedef {function(number,number,number):number} FindBlocksSortValueFunction Signature: `(distance: number, pointValue: number, digTime: number) => number`
+     */
+
+    /**
      * Returns the best block that is diggable within a maximum distance from the Bot.
      * @param {object} [options] optional parameters
      * @param {string[]} [options.blockNames=[]] List of blockNames to consider
@@ -863,8 +900,8 @@ const RGBot = class {
      * @param {boolean} [options.onlyFindTopBlocks=false] Only find blocks that don't have a block above them.
      * @param {number} [options.maxDistance=30] Max range to consider.  Be careful as large values have performance implications.  30 means up to 60x60x60 (216000) blocks could be evaluated.  50 means up to 100x100x100 (1000000) blocks could be evaluated
      * @param {number} [options.maxCount=1] Max count of matching blocks
-     * @param {function(blockName:string):number} [options.blockValueFunction] Function to call to get the value of a block based on its name (blockName). A good example function is { return scoreValueOf[blockName] }, where scoreValueOf is the point value or intrinsic value of the block in the game mode being played.  If you don't want a block considered, return a value < 0 for its value. Default value is 0 if no function is provided.
-     * @param {function(distance:number,pointValue:number,digTime:number):number} [options.sortValueFunction] Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION
+     * @param {FindBlocksBlockValueFunction} [options.blockValueFunction] Signature: `(blockName: string) => number`. Function to call to get the value of a block based on its name (blockName). A good example function is { return scoreValueOf[blockName] }, where scoreValueOf is the point value or intrinsic value of the block in the game mode being played.  If you don't want a block considered, return a value < 0 for its value. Default value is 0 if no function is provided.
+     * @param {FindBlocksSortValueFunction} [options.sortValueFunction] Signature: `(distance: number, pointValue: number, digTime: number) => number`. Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION
      * @returns {FindResult[]} - the best blocks found
      *
      * To get only the 'best' block result, call findBlocks(...).shift().  Note that the result may be null if no blocks were found
@@ -1189,14 +1226,28 @@ const RGBot = class {
     }
 
     /**
+     * TypeScript JSDoc:
+     * @typedef {(blockName: string) => number} FindItemsOnGroundItemValueFunction
+     * @typedef {(distance: number, pointValue: number) => number} FindItemsOnGroundSortValueFunction
+     */
+
+    /**
+     * @typedef {function(string):number} FindItemsOnGroundItemValueFunction  Signature: `(blockName: string) => number`
+     */
+
+    /**
+     * @typedef {function(number,number):number} FindItemsOnGroundSortValueFunction Signature: `(distance: number, pointValue: number) => number`
+     */
+
+    /**
      * Returns a list of all Items that are on the ground within a maximum distance from the Bot (can be empty).
      * @param {object} [options] optional parameters
      * @param {string[]} [options.itemNames=[]] Find only Items matching one of these names
      * @param {boolean} [options.partialMatch=false] If itemNames is defined, find Items whose name contains any of the itemNames. (Ex. '_boots' may find any of 'iron_boots', 'golden_boots', etc.)
      * @param {number} [options.maxDistance=undefined] find any Items matching the search criteria up to and including this distance from the Bot
      * @param {number} [options.maxCount=1] limit the number of items to find
-     * @param {function(blockName:string):number} [options.itemValueFunction] function to call to get the value of an item based on its name (itemName). A good example function is { return scoreValueOf[itemName] }, where scoreValueOf is the point value or intrinsic value of the item in the game mode being played.  If you don't want an item considered, return a value < 0 for its value.  Default value is 0.
-     * @param {function(distance:number,pointValue:number):number} [options.sortValueFunction] function to call to help sort the evaluation of results. Should return the best item with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION
+     * @param {FindItemsOnGroundItemValueFunction} [options.itemValueFunction] Signature: `(blockName: string) => number`. Function to call to get the value of an item based on its name (itemName). A good example function is { return scoreValueOf[itemName] }, where scoreValueOf is the point value or intrinsic value of the item in the game mode being played.  If you don't want an item considered, return a value < 0 for its value.  Default value is 0.
+     * @param {FindItemsOnGroundSortValueFunction} [options.sortValueFunction] Signature: `(distance: number, pointValue: number) => number`. Function to call to help sort the evaluation of results. Should return the best item with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION
      *
      * @returns {FindResult[]} - the best items found
      *
@@ -1364,7 +1415,7 @@ const RGBot = class {
      * @param {string} itemName
      * @param {object} [options={}] Optional parameters
      * @param {boolean} [options.partialMatch=false] Count any items whose name contains itemName. (Ex. 'wooden_axe', 'stone_axe', 'diamond_axe', etc. will all be included in the quantity for itemName 'axe').
-     * @returns {int}
+     * @returns {number}
      */
     getInventoryItemQuantity(itemName, options = {}) {
         const partialMatch = options.partialMatch || false;

--- a/lib/RGBot.js
+++ b/lib/RGBot.js
@@ -598,7 +598,7 @@ class RGBot {
      * @param {FindEntitiesEntityValueFunction} [options.entityValueFunction] Function to call to get the value of an entity based on its name (entityName). A good example function is { return scoreValueOf[entityUsername || entityName] }, where scoreValueOf is the point value or intrinsic value of the entity in the game mode being played.  If you don't want an entity considered, return a value < 0 for its value. Default value is 0 if no function is provided.
      * @param {FindEntitiesSortValueFunction} [options.sortValueFunction] Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION
      *
-     * @return {FindResult[]}
+     * @return {Array<FindResult<Entity>>}
      *
      * To get only the 'best' entity result, call findEntities(...).shift().  Note that the result may be null if no entities were found
      */
@@ -903,7 +903,7 @@ class RGBot {
      * @param {number} [options.maxCount=1] Max count of matching blocks
      * @param {FindBlocksBlockValueFunction} [options.blockValueFunction] Function to call to get the value of a block based on its name (blockName). A good example function is { return scoreValueOf[blockName] }, where scoreValueOf is the point value or intrinsic value of the block in the game mode being played.  If you don't want a block considered, return a value < 0 for its value. Default value is 0 if no function is provided.
      * @param {FindBlocksSortValueFunction} [options.sortValueFunction] Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION
-     * @returns {FindResult[]} - the best blocks found
+     * @returns {Array<FindResult<Block>>} - the best blocks found
      *
      * To get only the 'best' block result, call findBlocks(...).shift().  Note that the result may be null if no blocks were found
      */
@@ -1249,7 +1249,7 @@ class RGBot {
      * @param {FindItemsOnGroundItemValueFunction} [options.itemValueFunction] Function to call to get the value of an item based on its name (itemName). A good example function is { return scoreValueOf[itemName] }, where scoreValueOf is the point value or intrinsic value of the item in the game mode being played.  If you don't want an item considered, return a value < 0 for its value.  Default value is 0.
      * @param {FindItemsOnGroundSortValueFunction} [options.sortValueFunction] Function to call to help sort the evaluation of results. Should return the best item with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION
      *
-     * @returns {FindResult[]} - the best items found
+     * @returns {Array<FindResult<Item>>} - the best items found
      *
      * To get only the 'best' item to collect, call findItems(...).shift().  Note that the result may be null if no items were found
      */

--- a/lib/RGBot.js
+++ b/lib/RGBot.js
@@ -572,17 +572,19 @@ class RGBot {
     }
 
     /**
-     * TypeScript JSDoc:
-     * @typedef {(entityName: string) => number} FindEntitiesEntityValueFunction
-     * @typedef {(distance: number, pointValue: number, health: number, defense: number, toughness: number) => number} FindEntitiesSortValueFunction
+     * @callback FindEntitiesEntityValueFunction
+     * @param {string} entityName
+     * @returns {number}
      */
 
     /**
-     * @typedef {function(string):number} FindEntitiesEntityValueFunction  Signature: `(entityName: string) => number`
-     */
-
-    /**
-     * @typedef {function(number,number,number,number,number):number} FindEntitiesSortValueFunction Signature: `(distance: number, pointValue: number, health: number, defense: number, toughness: number) => number`
+     * @callback FindEntitiesSortValueFunction
+     * @param {number} distance
+     * @param {number} pointValue
+     * @param {number} health
+     * @param {number} defense
+     * @param {number} toughness
+     * @returns {number}
      */
 
     /**
@@ -594,8 +596,8 @@ class RGBot {
      * @param {boolean} [options.partialMatch=false] Consider entities whose username or name partially match one of the targetNames
      * @param {number} [options.maxDistance=undefined]  Max range to consider
      * @param {number} [options.maxCount=1]  Max count of matching entities to consider
-     * @param {FindEntitiesEntityValueFunction} [options.entityValueFunction] Signature: `(entityName: string) => number`. Function to call to get the value of an entity based on its name (entityName). A good example function is { return scoreValueOf[entityUsername || entityName] }, where scoreValueOf is the point value or intrinsic value of the entity in the game mode being played.  If you don't want an entity considered, return a value < 0 for its value. Default value is 0 if no function is provided.
-     * @param {FindEntitiesSortValueFunction} [options.sortValueFunction] Signature: `(distance: number, pointValue: number, health: number, defense: number, toughness: number) => number`. Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION
+     * @param {FindEntitiesEntityValueFunction} [options.entityValueFunction] Function to call to get the value of an entity based on its name (entityName). A good example function is { return scoreValueOf[entityUsername || entityName] }, where scoreValueOf is the point value or intrinsic value of the entity in the game mode being played.  If you don't want an entity considered, return a value < 0 for its value. Default value is 0 if no function is provided.
+     * @param {FindEntitiesSortValueFunction} [options.sortValueFunction] Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ENTITIES_SORT_VALUE_FUNCTION
      *
      * @return {FindResult[]}
      *
@@ -879,17 +881,17 @@ class RGBot {
     }
 
     /**
-     * TypeScript JSDoc:
-     * @typedef {(blockName: string) => number} FindBlocksBlockValueFunction
-     * @typedef {(distance: number, pointValue: number, digTime: number) => number} FindBlocksSortValueFunction
+     * @callback FindBlocksBlockValueFunction
+     * @param {string} blockName
+     * @returns {number}
      */
 
     /**
-     * @typedef {function(string):number} FindBlocksBlockValueFunction  Signature: `(blockName: string) => number`
-     */
-
-    /**
-     * @typedef {function(number,number,number):number} FindBlocksSortValueFunction Signature: `(distance: number, pointValue: number, digTime: number) => number`
+     * @callback FindBlocksSortValueFunction
+     * @param {number} distance
+     * @param {number} pointValue
+     * @param {number} digTime
+     * @returns {number}
      */
 
     /**
@@ -900,8 +902,8 @@ class RGBot {
      * @param {boolean} [options.onlyFindTopBlocks=false] Only find blocks that don't have a block above them.
      * @param {number} [options.maxDistance=30] Max range to consider.  Be careful as large values have performance implications.  30 means up to 60x60x60 (216000) blocks could be evaluated.  50 means up to 100x100x100 (1000000) blocks could be evaluated
      * @param {number} [options.maxCount=1] Max count of matching blocks
-     * @param {FindBlocksBlockValueFunction} [options.blockValueFunction] Signature: `(blockName: string) => number`. Function to call to get the value of a block based on its name (blockName). A good example function is { return scoreValueOf[blockName] }, where scoreValueOf is the point value or intrinsic value of the block in the game mode being played.  If you don't want a block considered, return a value < 0 for its value. Default value is 0 if no function is provided.
-     * @param {FindBlocksSortValueFunction} [options.sortValueFunction] Signature: `(distance: number, pointValue: number, digTime: number) => number`. Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION
+     * @param {FindBlocksBlockValueFunction} [options.blockValueFunction] Function to call to get the value of a block based on its name (blockName). A good example function is { return scoreValueOf[blockName] }, where scoreValueOf is the point value or intrinsic value of the block in the game mode being played.  If you don't want a block considered, return a value < 0 for its value. Default value is 0 if no function is provided.
+     * @param {FindBlocksSortValueFunction} [options.sortValueFunction] Function to call to help sort the evaluation of results. Should return the best entity with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_BLOCKS_SORT_VALUE_FUNCTION
      * @returns {FindResult[]} - the best blocks found
      *
      * To get only the 'best' block result, call findBlocks(...).shift().  Note that the result may be null if no blocks were found
@@ -1226,17 +1228,16 @@ class RGBot {
     }
 
     /**
-     * TypeScript JSDoc:
-     * @typedef {(blockName: string) => number} FindItemsOnGroundItemValueFunction
-     * @typedef {(distance: number, pointValue: number) => number} FindItemsOnGroundSortValueFunction
+     * @callback FindItemsOnGroundItemValueFunction
+     * @param {string} blockName
+     * @returns {number}
      */
 
     /**
-     * @typedef {function(string):number} FindItemsOnGroundItemValueFunction  Signature: `(blockName: string) => number`
-     */
-
-    /**
-     * @typedef {function(number,number):number} FindItemsOnGroundSortValueFunction Signature: `(distance: number, pointValue: number) => number`
+     * @callback FindItemsOnGroundSortValueFunction
+     * @param {number} distance
+     * @param {number} pointValue
+     * @returns {number}
      */
 
     /**
@@ -1246,8 +1247,8 @@ class RGBot {
      * @param {boolean} [options.partialMatch=false] If itemNames is defined, find Items whose name contains any of the itemNames. (Ex. '_boots' may find any of 'iron_boots', 'golden_boots', etc.)
      * @param {number} [options.maxDistance=undefined] find any Items matching the search criteria up to and including this distance from the Bot
      * @param {number} [options.maxCount=1] limit the number of items to find
-     * @param {FindItemsOnGroundItemValueFunction} [options.itemValueFunction] Signature: `(blockName: string) => number`. Function to call to get the value of an item based on its name (itemName). A good example function is { return scoreValueOf[itemName] }, where scoreValueOf is the point value or intrinsic value of the item in the game mode being played.  If you don't want an item considered, return a value < 0 for its value.  Default value is 0.
-     * @param {FindItemsOnGroundSortValueFunction} [options.sortValueFunction] Signature: `(distance: number, pointValue: number) => number`. Function to call to help sort the evaluation of results. Should return the best item with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION
+     * @param {FindItemsOnGroundItemValueFunction} [options.itemValueFunction] Function to call to get the value of an item based on its name (itemName). A good example function is { return scoreValueOf[itemName] }, where scoreValueOf is the point value or intrinsic value of the item in the game mode being played.  If you don't want an item considered, return a value < 0 for its value.  Default value is 0.
+     * @param {FindItemsOnGroundSortValueFunction} [options.sortValueFunction] Function to call to help sort the evaluation of results. Should return the best item with the lowest sorting value.  Default is RGAlgorithms.DEFAULT_FIND_ITEMS_ON_GROUND_SORT_VALUE_FUNCTION
      *
      * @returns {FindResult[]} - the best items found
      *

--- a/lib/RGBot.js
+++ b/lib/RGBot.js
@@ -43,7 +43,6 @@ const RGAlgorithms = require('./RGAlgorithms')
  */
 class RGBot {
     /**
-     * TypeScript JSDoc:
      * @typedef { import('mineflayer').Bot } Bot
      * @typedef { import('events').EventEmitter } EventEmitter
      * @typedef { import('prismarine-item').Item } Item

--- a/lib/RGModels.js
+++ b/lib/RGModels.js
@@ -1,7 +1,5 @@
 /**
  * @typedef { import('prismarine-item').Item } Item
- * @typedef { import('prismarine-entity').Entity } Entity
- * @typedef { import('prismarine-block').Block } Block
  */
 
 /**
@@ -32,8 +30,9 @@ class BestHarvestTool {
 /**
  * The result of a findEntities, findBlocks, findItemsOnGround operation.
  *
- * @param {Entity|Item|Block} result The result object
+ * @param {T} result The result object
  * @param {number} value The value computed for this result during evaluation
+ * @template T
  */
 class FindResult {
 
@@ -43,7 +42,7 @@ class FindResult {
     }
 
     /**
-     * @type {Entity|Item|Block}
+     * @type {T}
      */
     result;
 

--- a/lib/RGModels.js
+++ b/lib/RGModels.js
@@ -1,10 +1,17 @@
 /**
+ * TypeScript JSDoc:
+ * @typedef { import('prismarine-item').Item } Item
+ * @typedef { import('prismarine-entity').Entity } Entity
+ * @typedef { import('prismarine-block').Block } Block
+ */
+
+/**
  *
  * A result model for finding the best harvesting tool including the tool if found and the digTime for that tool/block combo.
  * The digTime will be Infinity if the block is not diggable with any tool the bot has.
  *
  * @param  {Item|null} tool The Item best suited to dig the block.  Can be null if no tool is needed or if item is not diggable.
- * @param  {number} digTime Time in milliseconds to dig the block, Infinity if not diggable
+ * @param  {number} [digTime=Infinity] Time in milliseconds to dig the block, Infinity if not diggable
  */
 class BestHarvestTool {
     constructor(tool, digTime = Infinity) {
@@ -13,7 +20,7 @@ class BestHarvestTool {
     }
 
     /**
-     * @type {Item}
+     * @type {Item|null}
      */
     tool;
 
@@ -29,7 +36,7 @@ class BestHarvestTool {
  * @param {Entity|Item|Block} result The result object
  * @param {number} value The value computed for this result during evaluation
  */
-const FindResult = class {
+class FindResult {
 
     constructor(result, value) {
         this.result = result

--- a/lib/RGModels.js
+++ b/lib/RGModels.js
@@ -1,5 +1,4 @@
 /**
- * TypeScript JSDoc:
  * @typedef { import('prismarine-item').Item } Item
  * @typedef { import('prismarine-entity').Entity } Entity
  * @typedef { import('prismarine-block').Block } Block

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.1",
   "description": "A library allowing users to easily design and control Regression Games bots in a variety of games",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/Regression-Games/RegressionBot.git"
@@ -10,7 +11,8 @@
   "scripts": {
     "prepare": "husky install",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "docs": "jsdoc2md lib/*.js --plugin dmd-readable > docs/api.md"
+    "docs": "jsdoc2md lib/*.js --configure docs/jsdoc.json --plugin dmd-readable > docs/api.md",
+    "prepublishOnly": "tsc"
   },
   "author": "Regression Games, Inc",
   "license": "ISC",
@@ -30,6 +32,12 @@
   "devDependencies": {
     "dmd-readable": "^1.2.4",
     "husky": "^8.0.2",
-    "jsdoc-to-markdown": "^8.0.0"
-  }
+    "jsdoc-to-markdown": "^8.0.0",
+    "typescript": "^4.9.4"
+  },
+  "files": [
+    "index.js",
+    "lib/",
+    "types/"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "include": ["index.js", "lib/**/*"],
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "types",
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
This PR adds support for generating TypeScript definitions from the JSDoc comments. This way we can write bots in TypeScript with proper type definitions for everything in `rg-bot`.

A summary of the changes:
- TypeScript definitions are generated on the `prepublishOnly` command, meaning they are automatically updated every time an update is about to be published to NPM.
- TypeScript requires you to explicitly define where external types are coming from, which needs to be done using [TypeScript-specific JSDoc syntax](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#import-types) that JSDoc itself doesn't understand. To prevent `jsdoc2md` from breaking I added a JSDoc plugin that filters out that syntax when generating the API documentation.
- The JSDoc for method arguments that expect a function to be passed is currently "wrong". JSDoc can parse it, but not in the way you probably expect because JSDoc [does not support named parameters in function types](https://github.com/jsdoc/jsdoc/issues/1955). I changed those functions to types defined using `@callback` tags so that the function signatures (argument names and types) end up in the API documentation and so that TypeScript can parse it correctly.
- Made some other minor changes to fix small JSDoc mistakes and added some missing type information to improve the generated TypeScript definitions.
- Changed the `const X = class {` lines to `class X {` because TypeScript doesn't seem to like the former and I don't think there is a major difference between the two in JavaScript.

See [jmerle/rg-typescript-example](https://github.com/jmerle/rg-typescript-example) for an example bot which uses TypeScript (with the [@jmerle/rg-bot](https://www.npmjs.com/package/@jmerle/rg-bot) NPM package which contains TypeScript definitions generated by the changes in this PR).