### PR TITLE
[REG-503] Remove matchInfoEmitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ bot.on('spawn', function() {
 
 // or you can can choose to make calls to mineflayer through the RGBot for consistency
 // This will handle passing through listeners that are not RGBot specific to rg.mineflayer().on(...)
-rg.on('chat', async function (username, message) {
+rgbot.on('chat', async function (username, message) {
     if(username === rgbot.username()) return
     
     if(message === 'collect wood') {

--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ exports.configureBot = configureBot;
 import json
 import logging
 import threading
-import javascript
+import rg_javascript
 
-from javascript import require, On
+from rg_javascript import require, On
 
-mineflayer = require('mineflayer')
-mineflayer_pathfinder = require('mineflayer-pathfinder')
-rg_bot = require('rg-bot')
-rg_match_info = require('rg-match-info')
-Vec3 = require('vec3').Vec3
+mineflayer = require('mineflayer','4.5.1')
+mineflayer_pathfinder = require('mineflayer-pathfinder','2.4.0')
+rg_bot = require('rg-bot','1.4.0')
+rg_match_info = require('rg-match-info','1.0.0')
+Vec3 = require('vec3','0.1.7').Vec3
 
 logging.basicConfig(level=logging.NOTSET)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ and the [Mineflayer-Pathfinder](https://github.com/PrismarineJS/mineflayer-pathf
 RGBot offers a range of methods for interacting with the Minecraft world including placing and breaking Blocks,
 looting from and depositing into chests, and initiating combat.
 
+RGBot also supports using Python3 for Mineflayer bots via the https://github.com/extremeheat/JSPyBridge project that
+bridges from Python into NodeJS Javascript.  Note that this works for diehard Python fans, but is slower than using
+Javascript as all calls into RGBot or Mineflayer APIs use inter process communication to go between the Python and NodeJS
+runtimes.
+
+**!!!**
+**Note: Python3 bots will currently only work with NodeJS 14.x.y versions.  They will NOT work with 16.x.y versions.**
+**!!!**
+
 ### Usage within Regression Games
 
 The Regression Games platform requires an `index.js` file with an exported `configureBot` method which acts as an entrypoint into your bot script.
@@ -41,12 +50,12 @@ function configureBot(bot) {
     bot.setDebug(true);
 
     // announce in chat when Bot spawns
-    bot.on('spawn', function() {
+    bot.mineflayer().on('spawn', function() {
         bot.chat('Hello World');
     })
 
     // use in-game chat to make the Bot collect or drop wood for you
-    bot.on('chat', async function (username, message) {
+    bot.mineflayer().on('chat', async function (username, message) {
         if(username === bot.mineflayer().username) return
 
         if(message === 'collect wood') {
@@ -60,6 +69,45 @@ function configureBot(bot) {
 }
 
 exports.configureBot = configureBot;
+```
+
+```python
+import json
+import logging
+import threading
+import javascript
+
+from javascript import require, On
+
+mineflayer = require('mineflayer')
+mineflayer_pathfinder = require('mineflayer-pathfinder')
+rg_bot = require('rg-bot')
+rg_match_info = require('rg-match-info')
+Vec3 = require('vec3').Vec3
+
+logging.basicConfig(level=logging.NOTSET)
+
+
+def configure_bot(bot):
+
+    # turn on debug logging
+    # logs are displayed within the Regression Games app during a match
+    bot.setDebug(True)
+
+    # announce in chat when Bot spawns
+    @On(bot.mineflayer(), 'spawn')
+    def bot_on_spawn(this):
+        bot.chat('Hello World')
+
+    # use in-game chat to make the Bot collect or drop wood for you
+    @On(bot.mineflayer(), 'chat')
+    def bot_on_chat(username, message):
+        if username == bot.username():
+            return
+        if message == 'collect_wood':
+            bot.findAndDigBlock('log', {'partialMatch': True})
+        elif message == 'drop wood':
+            bot.dropInventoryItem('log', {'partialMatch': True, 'quantity': 1});
 ```
 
 ### External use

--- a/README.md
+++ b/README.md
@@ -50,28 +50,28 @@ Example:
 
 ```javascript
 /**
- * @param {RGBot} bot
+ * @param {RGBot} rgbot
  */
-function configureBot(bot) {
+function configureBot(rgbot) {
 
     // turn on debug logging 
     // logs are displayed within the Regression Games app during a match
-    bot.setDebug(true);
+    rgbot.setDebug(true);
 
     // announce in chat when Bot spawns
-    bot.mineflayer().on('spawn', function() {
-        bot.chat('Hello World');
+    rgbot.on('spawn', function() {
+        rgbot.chat('Hello World');
     })
 
     // use in-game chat to make the Bot collect or drop wood for you
-    bot.mineflayer().on('chat', async function (username, message) {
-        if(username === bot.mineflayer().username) return
+    rgbot.on('chat', async function (username, message) {
+        if(username === rgbot.username()) return
 
         if(message === 'collect wood') {
-            await bot.findAndDigBlock('log', {partialMatch: true});
+            await rgbot.findAndDigBlock('log', {partialMatch: true});
         }
         else if (message === 'drop wood') {
-            await bot.dropInventoryItem('log', {partialMatch: true, quantity: 1});
+            await rgbot.dropInventoryItem('log', {partialMatch: true, quantity: 1});
         }
     })
 
@@ -137,24 +137,24 @@ const bot = mineflayer.createBot({username: 'Bot'});
 
 // create an RGBot
 // RGBot interacts directly with your mineflayer Bot instance
-const rg = new RGBot(bot);
-rg.setDebug(true);
+const rgbot = new RGBot(bot);
+rgbot.setDebug(true);
 
 // you can invoke methods from both the mineflayer Bot and RGBot
 bot.on('spawn', function() {
-    rg.chat('Hello World');
+    rgbot.chat('Hello World');
 })
 
 // or you can can choose to make calls to mineflayer through the RGBot for consistency
 // This will handle passing through listeners that are not RGBot specific to rg.mineflayer().on(...)
 rg.on('chat', async function (username, message) {
-    if(username === rg.mineflayer().username) return
+    if(username === rgbot.username()) return
     
     if(message === 'collect wood') {
-        await rg.findAndDigBlock('log', {partialMatch: true});
+        await rgbot.findAndDigBlock('log', {partialMatch: true});
     }
     else if (message === 'drop wood') {
-        await rg.dropInventoryItem('log', {partialMatch: true, quantity: 1});
+        await rgbot.dropInventoryItem('log', {partialMatch: true, quantity: 1});
     }
 })
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -116,7 +116,6 @@ of point return vs time to reach further blocks, which often involves digging ot
     * [.lastAttackItem](#RGBot+lastAttackItem) : <code>Item</code>
     * [.setDebug(debug)](#RGBot+setDebug) ⇒ <code>void</code>
     * [.mineflayer()](#RGBot+mineflayer) ⇒ <code>Bot</code>
-    * [.on(event, func)](#RGBot+on) ⇒ <code>void</code>
     * [.allowParkour(allowParkour)](#RGBot+allowParkour) ⇒ <code>void</code>
     * [.allowDigWhilePathing(allowDig)](#RGBot+allowDigWhilePathing) ⇒ <code>void</code>
     * [.chat(message)](#RGBot+chat) ⇒ <code>void</code>
@@ -257,22 +256,6 @@ bot.lastAttackItem = attackItem
 ```js
 // returns the bot username from mineflayer
 rgBot.mineflayer().username
-```
-
-<br><a name="RGBot+on"></a>
-
-### rgBot.on(event, func) ⇒ <code>void</code>
-> Listen for an event and invoke a function when it fires.
-
-
-| Param | Type | Description |
-| --- | --- | --- |
-| event | <code>string</code> | The event to listen for |
-| func | <code>function</code> | Function that is invoked when event fires |
-
-**Example** *(Reacting to the spawn event)*  
-```js
-rgBot.on('spawn', () => { rgBot.chat('Hello World!') })
 ```
 
 <br><a name="RGBot+allowParkour"></a>

--- a/lib/RGBot.js
+++ b/lib/RGBot.js
@@ -1,3 +1,4 @@
+const { EventEmitter } = require('events')
 const mineflayer = require('mineflayer');
 const { RGMatchInfo } = require('rg-match-info')
 const { pathfinder, Movements } = require('mineflayer-pathfinder');
@@ -41,7 +42,7 @@ const RGAlgorithms = require('./RGAlgorithms')
  *    As an example, the Ender Dragon is the readable name, or display name, of the Entity named ender_dragon. Likewise, Grass Block is the display name of the block named grass_block.
  *    This library provides functions to accept the name but not the display name for conciseness and efficiency
  */
-class RGBot {
+class RGBot extends EventEmitter {
     /**
      * @typedef { import('mineflayer').Bot } Bot
      * @typedef { import('events').EventEmitter } EventEmitter
@@ -130,7 +131,8 @@ class RGBot {
      * @param {Bot} bot
      * @param {EventEmitter} matchInfoEmitter
      */
-    constructor(bot, matchInfoEmitter) {
+    constructor(bot) {
+        super();
 
         this.mcData = require('minecraft-data')(bot.version);
         this.debug = false;
@@ -145,19 +147,19 @@ class RGBot {
         this.#bot = bot;
 
         // Keep the match info up to date
-        matchInfoEmitter.on('player_left', (matchInfo, playerName, team) => {
+        this.on('player_left', (matchInfo, playerName, team) => {
             this.#matchInfo = matchInfo;
         })
-        matchInfoEmitter.on('player_joined', (matchInfo, playerName, team) => {
+        this.on('player_joined', (matchInfo, playerName, team) => {
             this.#matchInfo = matchInfo;
         })
-        matchInfoEmitter.on('score_update', (matchInfo) => {
+        this.on('score_update', (matchInfo) => {
             this.#matchInfo = matchInfo;
         })
-        matchInfoEmitter.on('match_ended', (matchInfo) => {
+        this.on('match_ended', (matchInfo) => {
             this.#matchInfo = matchInfo;
         })
-        matchInfoEmitter.on('match_started', (matchInfo) => {
+        this.on('match_started', (matchInfo) => {
             this.#matchInfo = matchInfo;
         })
 
@@ -251,19 +253,6 @@ class RGBot {
      */
     mineflayer() {
         return this.#bot;
-    }
-
-    /**
-     * Listen for an event and invoke a function when it fires.
-     * @param {string} event The event to listen for
-     * @param {function} func Function that is invoked when event fires
-     * @returns {void}
-     * 
-     * @example <caption>Reacting to the spawn event</caption>
-     * rgBot.on('spawn', () => { rgBot.chat('Hello World!') })
-     */
-    on(event, func) {
-        this.#bot.on(event, func);
     }
 
     /**

--- a/lib/RGBot.js
+++ b/lib/RGBot.js
@@ -1,6 +1,6 @@
 const { EventEmitter } = require('events')
 const mineflayer = require('mineflayer');
-const { RGMatchInfo, RGMatchInfoRequestType} = require('rg-match-info')
+const { RGMatchInfo, RGMatchInfoRequestType } = require('rg-match-info')
 const { pathfinder, Movements } = require('mineflayer-pathfinder');
 const { GoalNear, GoalPlaceBlock, GoalLookAtBlock, GoalXZ, GoalInvert, GoalFollow } = require('mineflayer-pathfinder').goals
 const { Vec3 } = require('vec3');
@@ -55,8 +55,11 @@ class RGBot extends EventEmitter {
     /**
      * Names of the RGBot/RGMatchInfo specific events.
      * @see RGMatchInfoRequestType
+     *
      */
-    #RG_EVENTS = Object.keys(RGMatchInfoRequestType).map( k => k.toLowerCase() );
+        // TODO? Future .. If we keep adding events, we may want to make RGMatchInfoRequestType into a non const enum so we can iterate on it
+        // #RG_EVENTS = Object.keys(RGMatchInfoRequestType).filter((item) => isNaN(Number(item))).map(k => k.toLowerCase());
+    #RG_EVENTS = ['score_update', 'player_joined', 'player_left', 'match_started', 'match_ended']
 
     /**
      * This value is read by the handlePath function to know if the bot is busy using a container while evaluating if it is stuck or not.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rg-bot",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A library allowing users to easily design and control Regression Games bots in a variety of games",
   "main": "index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
- Make RGBot an eventemitter itself
- Is backwards compatible with old bots by passing non RGBot/RGMatchInfo event listeners through to mineflayer automatically
- This also happens to clean up the issue where passing in a standalone EventEmitter for matchInfo events felt weird