### PR TITLE
[REG-739] [REG-674] handle null matchinfo in rgbot

### DIFF
--- a/lib/RGBot.js
+++ b/lib/RGBot.js
@@ -417,7 +417,7 @@ class RGBot extends EventEmitter {
      * @returns {string | null} Name of the team the player is on
      */
     teamForPlayer(username) {
-        let possiblePlayers = this.#matchInfo.players.filter(player => player.username === username)
+        let possiblePlayers = (this.#matchInfo && this.#matchInfo.players.filter(player => player.username === username)) || []
         if (possiblePlayers.length > 0 ) {
             return possiblePlayers[0].team
         }
@@ -439,9 +439,9 @@ class RGBot extends EventEmitter {
      */
     getTeammateUsernames(includeSelf) {
         const myTeam = this.getMyTeam();
-        return this.#matchInfo.players
+        return (this.#matchInfo && this.#matchInfo.players
             .filter(player => player.team === myTeam && (includeSelf || player.username !== this.username()))
-            .map(player => player.username)
+            .map(player => player.username)) || []
     }
 
     /**
@@ -450,9 +450,9 @@ class RGBot extends EventEmitter {
      */
     getOpponentUsernames() {
         const myTeam = this.getMyTeam();
-        return this.#matchInfo.players
+        return (this.#matchInfo && this.#matchInfo.players
             .filter(player => player.team !== myTeam)
-            .map(player => player.username)
+            .map(player => player.username)) || []
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rg-bot",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A library allowing users to easily design and control Regression Games bots in a variety of games",
   "main": "index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
- Keeps RGbot from vomitting when matchInfo is null
- Goes with other PR ([HERE](https://github.com/Regression-Games/RegressionGames/pull/202)) to keep matchInfo from ever being null