### PR TITLE
[REG-767] Fix RGBot attack pathing and following/avoiding

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -692,6 +692,7 @@ rgBot.findEntity({targetName: "chicken"})
 | --- | --- | --- | --- |
 | entity | <code>Entity</code> |  | The Entity to follow |
 | [options] | <code>object</code> | <code>{}</code> | Optional parameters |
+| [options.dynamic] | <code>boolean</code> | <code>true</code> | Whether this is a dynamic action. If dynamic, this will NOT block/await and will keep following the target in the background until a new pathfinding goal is set. If NOT dynamic, this will block/await until the target is reached and then stop pathing. |
 | [options.reach] | <code>number</code> | <code>2</code> | The Bot will follow and remain within this reach of the Entity |
 
 
@@ -707,6 +708,7 @@ rgBot.findEntity({targetName: "chicken"})
 | --- | --- | --- | --- |
 | entity | <code>Entity</code> |  | The Entity to avoid |
 | [options] | <code>object</code> | <code>{}</code> | Optional parameters |
+| [options.dynamic] | <code>boolean</code> | <code>true</code> | Whether this is a dynamic action. If dynamic, this will NOT block/await and will keep avoiding the target in the background until a new pathfinding goal is set. If NOT dynamic, this will block/await until the desired reach from the target is achieved and then stop pathing. |
 | [options.reach] | <code>number</code> | <code>5</code> | The Bot will not move within this reach of the Entity |
 
 

--- a/lib/RGBot.js
+++ b/lib/RGBot.js
@@ -797,16 +797,27 @@ class RGBot extends EventEmitter {
      * The Bot will follow the given Entity.
      * @param {Entity} entity The Entity to follow
      * @param {object} [options={}] Optional parameters
+     * @param {boolean} [options.dynamic=true] Whether this is a dynamic action.
+     * If dynamic, this will NOT block/await and will keep following the target in the background until a new
+     * pathfinding goal is set.
+     * If NOT dynamic, this will block/await until the target is reached and then stop pathing.
      * @param {number} [options.reach=2] The Bot will follow and remain within this reach of the Entity
      * @returns {Promise<void>}
      */
     async followEntity(entity, options = {}) {
         const reach = options.reach || 2;
+        const dynamic = options.dynamic || true;
         if (!entity) {
             this.#logWarn(`followEntity: Entity was null or undefined`);
         } else {
-            this.#logDebug(`Following ${this.getEntityName(entity)} within reach of ${reach}`);
-            this.#bot.pathfinder.setGoal(new GoalFollow(entity, reach), true);
+            if(dynamic) {
+                this.#logDebug(`Following ${this.getEntityName(entity)} within reach of ${reach}`);
+                // intentionally does NOT await; this lets the bot pathing follow around in the background
+                this.#bot.pathfinder.setGoal(new GoalFollow(entity, reach), true);
+            } else {
+                this.#logDebug(`Moving to ${this.getEntityName(entity)} within reach of ${reach}`);
+                await this.#bot.pathfinder.goto(new GoalFollow(entity, reach));
+            }
         }
     }
 
@@ -816,16 +827,27 @@ class RGBot extends EventEmitter {
      * The Bot will avoid the given Entity.
      * @param {Entity} entity The Entity to avoid
      * @param {object} [options={}] Optional parameters
+     * @param {boolean} [options.dynamic=true] Whether this is a dynamic action.
+     * If dynamic, this will NOT block/await and will keep avoiding the target in the background until a new
+     * pathfinding goal is set.
+     * If NOT dynamic, this will block/await until the desired reach from the target is achieved and then stop pathing.
      * @param {number} [options.reach=5] The Bot will not move within this reach of the Entity
      * @returns {Promise<void>}
      */
     async avoidEntity(entity, options = {}) {
         const reach = options.reach || 5;
+        const dynamic = options.dynamic || true;
         if (!entity) {
             this.#logWarn(`avoidEntity: Entity was null or undefined`);
         } else {
-            this.#logDebug(`Avoiding ${this.getEntityName(entity)} at a minimum reach of ${reach}`);
-            this.#bot.pathfinder.setGoal(new GoalInvert(new GoalFollow(entity, reach)), true);
+            if(dynamic) {
+                this.#logDebug(`Avoiding ${this.getEntityName(entity)} at a minimum reach of ${reach}`);
+                // intentionally does NOT await; this lets the bot pathing follow around in the background
+                this.#bot.pathfinder.setGoal(new GoalInvert(new GoalFollow(entity, reach)), true);
+            } else {
+                this.#logDebug(`Moving away from ${this.getEntityName(entity)} to a minimum reach of ${reach}`);
+                await this.#bot.pathfinder.goto(new GoalInvert(new GoalFollow(entity, reach)));
+            }
         }
     }
 
@@ -856,11 +878,7 @@ class RGBot extends EventEmitter {
         } else {
             try {
                 this.#logDebug(`Following and attacking entity ${entity.username || entity.name}`)
-                const moveGoal = new GoalNear(entity.position.x, entity.position.y, entity.position.z, reach)
-                await this.handlePath(async () => {
-                    await this.#bot.pathfinder.goto(moveGoal)
-                })
-                await this.followEntity(entity, {reach: reach})
+                await this.#bot.pathfinder.goto(new GoalFollow(entity, reach));
                 await this.waitForWeaponCoolDown()
                 // TODO: Verify if the target can be attacked melee (flying creatures can't be)
                 let attackItem = options.attackItem || this.bestAttackItemMelee()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rg-bot",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A library allowing users to easily design and control Regression Games bots in a variety of games",
   "main": "index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
- Enhances `followEntity`/`avoidEntity` to allow either
  - (NEW) awaiting the bot to get to within or away from 'reach' of the target
  - (PREVIOUS) follow/avoid the target at 'reach' until told to path somewhere else

- Fixes pathing bugs/deficiencies in `attackEntity`