### PR TITLE
feat: add function to get list of opponent usernames

### DIFF
--- a/lib/RGBot.js
+++ b/lib/RGBot.js
@@ -487,6 +487,18 @@ class RGBot extends EventEmitter {
     }
 
     /**
+     * Returns a list of enemy usernames (relative to this bot).
+     * @return {string[]} A list of all team name of the opponents.
+     */
+    getOpponentTeamNames() {
+       const myTeam = this.getMyTeam();
+       const otherTeamName = this.matchInfo().teams.find(t => t.name != myTeam)?.name;
+       return (this.#matchInfo && this.#matchInfo.players
+        .filter(player => player.team === otherTeamName)
+        .map(player => player.username)) || []
+    }
+
+    /**
      * Gets the current position of the bot
      * @returns {Vec3}
      */


### PR DESCRIPTION
getOpponentTeamNames function to get enemy team name and return a list of enemy players' usernames.
@vontell kindly let me know if this is right. Thanks.


<img width="586" alt="Screenshot 2023-03-16 at 12 01 45 PM" src="https://user-images.githubusercontent.com/72856939/225597659-4c2d6a06-6dd3-4bfd-acf3-f10ec41613bc.png">

